### PR TITLE
Fixed toCDXLine digest field

### DIFF
--- a/src/main/java/uk/bl/wap/util/OutbackCDXClient.java
+++ b/src/main/java/uk/bl/wap/util/OutbackCDXClient.java
@@ -553,7 +553,7 @@ public class OutbackCDXClient {
         sb.append(" ");
         sb.append(fetch_status);
         sb.append(" ");
-        sb.append(curi.getContentDigestSchemeString());
+        sb.append(curi.getContentDigestString());
         sb.append(" ");
         sb.append(curi.flattenVia());
         sb.append(" ");


### PR DESCRIPTION
Fixed issue where toCDXLine generates a digest using the scheme prefix instead of the raw sha1 value. Now uses getContentDigestString instead of getContentDigestSchemeString